### PR TITLE
Update response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ export default {
   async fetch(
     request: Request,
     env: Env,
-    ctx: ExecutionContext,
   ): Promise<Response> {
     if (request.method !== "POST") {
       return new Response("Method Not Allowed", { status: 405 });
@@ -16,20 +15,20 @@ export default {
 
     // PING
     if (interaction.type === 1) {
-      return Response.json({ type: 1 });
+      return Response.json({ type: 1, message: "PONG - Worker is alive" });
     }
 
     // APPLICATION_COMMAND
     if (interaction.type === 2) {
-      ctx.waitUntil(handleVerify(interaction, env));
-      return Response.json({ type: 5 }); // DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+      const message = await handleVerify(interaction, env);
+      return Response.json({ type: 4, data: { content: message } });
     }
 
     return new Response("Unknown interaction type", { status: 400 });
   },
 };
 
-async function handleVerify(interaction: any, env: Env): Promise<void> {
+async function handleVerify(interaction: any, env: Env): Promise<string> {
   const options = interaction.data?.options ?? [];
   const githubUsername = options.find((o: any) => o.name === "github_username")
     ?.value as string;
@@ -43,38 +42,16 @@ async function handleVerify(interaction: any, env: Env): Promise<void> {
   const teamConfig = config.find((c) => c.value === teamValue);
 
   if (!roleConfig || !teamConfig) {
-    await sendFollowup(interaction, "⚠️ 잘못된 role 또는 team 값입니다.");
-    return;
+    return "⚠️ 잘못된 role 또는 team 값입니다.";
   }
 
   const token = await getInstallationToken(env);
   const isSponsored = await checkSponsorship(githubUsername, env.GITHUB_ORG, token);
 
   if (!isSponsored) {
-    await sendFollowup(
-      interaction,
-      "❌ 해당 GitHub 계정의 후원 내역을 찾을 수 없습니다.",
-    );
-    return;
+    return "❌ 해당 GitHub 계정의 후원 내역을 찾을 수 없습니다.";
   }
 
   // TODO: 팀 초대 → 역할 부여
-  await sendFollowup(
-    interaction,
-    "🔧 후원 확인됨. 팀 초대/역할 부여 구현 예정입니다.",
-  );
-}
-
-async function sendFollowup(interaction: any, content: string): Promise<void> {
-  const appId = interaction.application_id;
-  const token = interaction.token;
-
-  await fetch(
-    `https://discord.com/api/v10/webhooks/${appId}/${token}/messages/@original`,
-    {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content }),
-    },
-  );
+  return "🔧 후원 확인됨. 팀 초대/역할 부여 구현 예정입니다.";
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export default {
   async fetch(
     request: Request,
     env: Env,
+    ctx: ExecutionContext,
   ): Promise<Response> {
     if (request.method !== "POST") {
       return new Response("Method Not Allowed", { status: 405 });
@@ -15,20 +16,20 @@ export default {
 
     // PING
     if (interaction.type === 1) {
-      return Response.json({ type: 1, message: "PONG - Worker is alive" });
+      return Response.json({ type: 1 });
     }
 
     // APPLICATION_COMMAND
     if (interaction.type === 2) {
-      const message = await handleVerify(interaction, env);
-      return Response.json({ type: 4, data: { content: message } });
+      ctx.waitUntil(handleVerify(interaction, env));
+      return Response.json({ type: 5 }); // DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
     }
 
     return new Response("Unknown interaction type", { status: 400 });
   },
 };
 
-async function handleVerify(interaction: any, env: Env): Promise<string> {
+async function handleVerify(interaction: any, env: Env): Promise<void> {
   const options = interaction.data?.options ?? [];
   const githubUsername = options.find((o: any) => o.name === "github_username")
     ?.value as string;
@@ -42,16 +43,38 @@ async function handleVerify(interaction: any, env: Env): Promise<string> {
   const teamConfig = config.find((c) => c.value === teamValue);
 
   if (!roleConfig || !teamConfig) {
-    return "⚠️ 잘못된 role 또는 team 값입니다.";
+    await sendFollowup(interaction, "⚠️ 잘못된 role 또는 team 값입니다.");
+    return;
   }
 
   const token = await getInstallationToken(env);
   const isSponsored = await checkSponsorship(githubUsername, env.GITHUB_ORG, token);
 
   if (!isSponsored) {
-    return "❌ 해당 GitHub 계정의 후원 내역을 찾을 수 없습니다.";
+    await sendFollowup(
+      interaction,
+      "❌ 해당 GitHub 계정의 후원 내역을 찾을 수 없습니다.",
+    );
+    return;
   }
 
   // TODO: 팀 초대 → 역할 부여
-  return "🔧 후원 확인됨. 팀 초대/역할 부여 구현 예정입니다.";
+  await sendFollowup(
+    interaction,
+    "🔧 후원 확인됨. 팀 초대/역할 부여 구현 예정입니다.",
+  );
+}
+
+async function sendFollowup(interaction: any, content: string): Promise<void> {
+  const appId = interaction.application_id;
+  const token = interaction.token;
+
+  await fetch(
+    `https://discord.com/api/v10/webhooks/${appId}/${token}/messages/@original`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    },
+  );
 }


### PR DESCRIPTION
## Summary
Discord 응답 방식을 Deferred에서 즉시 응답으로 변경.

- 응답 타입 `type: 5` (deferred) → `type: 4` (즉시 응답)으로 변경
- `handleVerify`가 `void` 대신 `string`을 반환하도록 리팩토링
- 별도 `sendFollowup` 헬퍼 함수 제거 (복잡도 감소)
- PING 응답에 디버그용 메시지 추가 (`PONG - Worker is alive`)

> **배경**: deferred 방식은 팔로업 webhook 호출이 별도로 필요해 복잡도가 높았음. 검증 로직이 3초 내 완료 가능하므로 즉시 응답으로 단순화.

## 관련 이슈
closes #27