### PR TITLE
Skips role/team validation to allow direct sponsorship check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,13 +37,13 @@ async function handleVerify(interaction: any, env: Env): Promise<string> {
   const teamValue = options.find((o: any) => o.name === "team")
     ?.value as string;
 
-  const config: RoleTeamConfig[] = JSON.parse(env.ROLE_TEAM_CONFIG);
-  const roleConfig = config.find((c) => c.value === roleValue);
-  const teamConfig = config.find((c) => c.value === teamValue);
+  // const config: RoleTeamConfig[] = JSON.parse(env.ROLE_TEAM_CONFIG);
+  // const roleConfig = config.find((c) => c.value === roleValue);
+  // const teamConfig = config.find((c) => c.value === teamValue);
 
-  if (!roleConfig || !teamConfig) {
-    return "⚠️ 잘못된 role 또는 team 값입니다.";
-  }
+  // if (!roleConfig || !teamConfig) {
+  //   return "⚠️ 잘못된 role 또는 team 값입니다.";
+  // }
 
   const token = await getInstallationToken(env);
   const isSponsored = await checkSponsorship(githubUsername, env.GITHUB_ORG, token);


### PR DESCRIPTION
## Summary
- `handleVerify`에서 role/team config 검증 로직을 주석 처리
- github_username만으로 후원 여부 확인 가능하도록 변경

## Test plan
- [ ] POST `https://community-manager.dalestudy.workers.dev` with `type: 2` and `github_username` only
- [ ] 후원된 계정 → `🔧 후원 확인됨` 응답 확인
- [ ] 미후원 계정 → `❌ 해당 GitHub 계정의 후원 내역을 찾을 수 없습니다.` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)