### PR TITLE
Add test

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -37,8 +37,8 @@ export async function checkSponsorship(
 ): Promise<boolean> {
   const query = `
     query($login: String!, $org: String!) {
-      user(login: $login) {
-        isSponsoredBy(accountLogin: $org)
+      organization(login: $org) {
+        isSponsoredBy(accountLogin: $login)
       }
     }
   `;
@@ -60,7 +60,7 @@ export async function checkSponsorship(
     throw new Error(`GraphQL error: ${JSON.stringify(result.errors)}`);
   }
 
-  return result.data?.user?.isSponsoredBy === true;
+  return result.data?.organization?.isSponsoredBy === true;
 }
 
 /**
@@ -87,15 +87,44 @@ async function importPrivateKey(pem: string): Promise<CryptoKey> {
   const pemFooter = isPKCS8 ? "-----END PRIVATE KEY-----" : "-----END RSA PRIVATE KEY-----";
 
   const pemContents = pem.replace(pemHeader, "").replace(pemFooter, "").replace(/\s/g, "");
-  const binaryDer = Uint8Array.from(atob(pemContents), (c) => c.charCodeAt(0));
+  const pkcs1Der = Uint8Array.from(atob(pemContents), (c) => c.charCodeAt(0));
+
+  // GitHub App 키는 PKCS1 형식이므로 PKCS8로 변환
+  const keyData = isPKCS8 ? pkcs1Der : pkcs1ToPkcs8(pkcs1Der);
 
   return crypto.subtle.importKey(
     "pkcs8",
-    binaryDer,
+    keyData,
     { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
     false,
     ["sign"]
   );
+}
+
+function pkcs1ToPkcs8(pkcs1: Uint8Array): Uint8Array {
+  function encodeLength(len: number): Uint8Array {
+    if (len < 128) return new Uint8Array([len]);
+    if (len < 256) return new Uint8Array([0x81, len]);
+    return new Uint8Array([0x82, (len >> 8) & 0xff, len & 0xff]);
+  }
+
+  function concat(...arrays: Uint8Array[]): Uint8Array {
+    const total = arrays.reduce((sum, a) => sum + a.length, 0);
+    const result = new Uint8Array(total);
+    let offset = 0;
+    for (const a of arrays) { result.set(a, offset); offset += a.length; }
+    return result;
+  }
+
+  const version = new Uint8Array([0x02, 0x01, 0x00]);
+  const rsaOid = new Uint8Array([
+    0x30, 0x0d,
+    0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01,
+    0x05, 0x00,
+  ]);
+  const octetString = concat(new Uint8Array([0x04]), encodeLength(pkcs1.length), pkcs1);
+  const inner = concat(version, rsaOid, octetString);
+  return concat(new Uint8Array([0x30]), encodeLength(inner.length), inner);
 }
 
 async function sign(data: string, key: CryptoKey): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,13 +37,13 @@ async function handleVerify(interaction: any, env: Env): Promise<string> {
   const teamValue = options.find((o: any) => o.name === "team")
     ?.value as string;
 
-  const config: RoleTeamConfig[] = JSON.parse(env.ROLE_TEAM_CONFIG);
-  const roleConfig = config.find((c) => c.value === roleValue);
-  const teamConfig = config.find((c) => c.value === teamValue);
+  // const config: RoleTeamConfig[] = JSON.parse(env.ROLE_TEAM_CONFIG);
+  // const roleConfig = config.find((c) => c.value === roleValue);
+  // const teamConfig = config.find((c) => c.value === teamValue);
 
-  if (!roleConfig || !teamConfig) {
-    return "⚠️ 잘못된 role 또는 team 값입니다.";
-  }
+  // if (!roleConfig || !teamConfig) {
+  //   return "⚠️ 잘못된 role 또는 team 값입니다.";
+  // }
 
   const token = await getInstallationToken(env);
   const isSponsored = await checkSponsorship(githubUsername, env.GITHUB_ORG, token);


### PR DESCRIPTION
## Summary
GraphQL 쿼리 방향 수정 및 GitHub App 키 포맷 호환성 처리.

- GraphQL 후원 확인 쿼리를 `user.isSponsoredBy` → `organization.isSponsoredBy`로 수정
  - 기존: 후원받는 유저 기준 조회 → 실제 DaleStudy 조직 기준으로 수정 필요
- GitHub App 프라이빗 키가 PKCS1 형식으로 발급되는데 Web Crypto API는 PKCS8만 지원하는 문제 해결
  - `pkcs1ToPkcs8()` 변환 함수 추가 (ASN.1 DER 직접 조작)
- role/team config 검증 로직 임시 주석 처리 (후원 확인 단독 테스트 목적)

## 관련 이슈
closes #27