### PR TITLE
update sponsor logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250407.0",
+        "@types/node": "^25.6.0",
         "typescript": "^5.0.0",
         "vitest": "^3.2.4",
         "wrangler": "^3.0.0"
@@ -1350,6 +1351,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -2324,6 +2335,13 @@
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.14",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "community-manager",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250407.0",
+    "@types/node": "^25.6.0",
     "typescript": "^5.0.0",
     "vitest": "^3.2.4",
     "wrangler": "^3.0.0"

--- a/src/discord.test.ts
+++ b/src/discord.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { webcrypto } from "node:crypto";
+import { verifySignature } from "./discord.js";
+
+beforeAll(() => {
+  vi.stubGlobal("crypto", webcrypto);
+});
+
+async function generateKeyPair(): Promise<CryptoKeyPair> {
+  return crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]) as Promise<CryptoKeyPair>;
+}
+
+async function sign(privateKey: CryptoKey, timestamp: string, body: string): Promise<string> {
+  const message = new TextEncoder().encode(timestamp + body);
+  const signature = await crypto.subtle.sign("Ed25519", privateKey, message);
+  return Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function exportPublicKeyHex(publicKey: CryptoKey): Promise<string> {
+  const raw = await crypto.subtle.exportKey("raw", publicKey) as ArrayBuffer;
+  return Array.from(new Uint8Array(raw))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+describe("verifySignature", () => {
+  it("올바른 서명이면 true를 반환한다", async () => {
+    const { privateKey, publicKey } = await generateKeyPair();
+    const publicKeyHex = await exportPublicKeyHex(publicKey);
+    const timestamp = "1700000000";
+    const body = '{"type":1}';
+    const signature = await sign(privateKey, timestamp, body);
+
+    const result = await verifySignature(publicKeyHex, signature, timestamp, body);
+    expect(result).toBe(true);
+  });
+
+  it("서명이 잘못된 경우 false를 반환한다", async () => {
+    const { publicKey } = await generateKeyPair();
+    const publicKeyHex = await exportPublicKeyHex(publicKey);
+
+    const result = await verifySignature(
+      publicKeyHex,
+      "a".repeat(128),
+      "1700000000",
+      '{"type":1}',
+    );
+    expect(result).toBe(false);
+  });
+
+  it("body가 다르면 false를 반환한다", async () => {
+    const { privateKey, publicKey } = await generateKeyPair();
+    const publicKeyHex = await exportPublicKeyHex(publicKey);
+    const timestamp = "1700000000";
+    const signature = await sign(privateKey, timestamp, '{"type":1}');
+
+    const result = await verifySignature(publicKeyHex, signature, timestamp, '{"type":2}');
+    expect(result).toBe(false);
+  });
+
+  it("timestamp가 다르면 false를 반환한다", async () => {
+    const { privateKey, publicKey } = await generateKeyPair();
+    const publicKeyHex = await exportPublicKeyHex(publicKey);
+    const body = '{"type":1}';
+    const signature = await sign(privateKey, "1700000000", body);
+
+    const result = await verifySignature(publicKeyHex, signature, "9999999999", body);
+    expect(result).toBe(false);
+  });
+});

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,0 +1,31 @@
+/**
+ * Discord Ed25519 서명 검증
+ */
+export async function verifySignature(
+  publicKey: string,
+  signature: string,
+  timestamp: string,
+  body: string,
+): Promise<boolean> {
+  const publicKeyBytes = hexToBytes(publicKey);
+  const signatureBytes = hexToBytes(signature);
+  const message = new TextEncoder().encode(timestamp + body);
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    publicKeyBytes,
+    { name: "Ed25519" },
+    false,
+    ["verify"],
+  );
+
+  return crypto.subtle.verify("Ed25519", key, signatureBytes, message);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { checkSponsorship, getInstallationToken, getTeamCreatedAt } from "./github.js";
+import { checkSponsorship, getInstallationToken, getTeamCreatedAt, inviteToTeam } from "./github.js";
 import type { Env } from "./types.js";
 
 const mockEnv: Env = {
@@ -181,6 +181,48 @@ describe("getTeamCreatedAt", () => {
     await expect(
       getTeamCreatedAt("DaleStudy", "nonexistent", "test-token"),
     ).rejects.toThrow("Failed to get team info");
+  });
+});
+
+describe("inviteToTeam", () => {
+  it("조직 멤버인 경우 active를 반환한다", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: "active" }),
+      }),
+    );
+
+    const result = await inviteToTeam("DaleStudy", "members", "octocat", "test-token");
+    expect(result).toBe("active");
+  });
+
+  it("조직 외부인인 경우 pending을 반환한다", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: "pending" }),
+      }),
+    );
+
+    const result = await inviteToTeam("DaleStudy", "members", "newuser", "test-token");
+    expect(result).toBe("pending");
+  });
+
+  it("API 실패 시 예외를 던진다", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ message: "Not Found" }),
+      }),
+    );
+
+    await expect(
+      inviteToTeam("DaleStudy", "nonexistent", "octocat", "test-token"),
+    ).rejects.toThrow("Failed to invite to team");
   });
 });
 

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { checkSponsorship, getInstallationToken } from "./github.js";
+import { checkSponsorship, getInstallationToken, getTeamCreatedAt } from "./github.js";
 import type { Env } from "./types.js";
 
 const mockEnv: Env = {
@@ -14,7 +14,7 @@ const mockEnv: Env = {
 };
 
 function makeSponsorshipResponse(
-  logins: string[],
+  sponsors: { login: string; createdAt?: string; amountInDollars?: number }[],
   hasNextPage = false,
   endCursor: string | null = null,
 ) {
@@ -24,8 +24,10 @@ function makeSponsorshipResponse(
         data: {
           organization: {
             sponsorshipsAsMaintainer: {
-              nodes: logins.map((login) => ({
+              nodes: sponsors.map(({ login, createdAt = "2024-01-01T00:00:00Z", amountInDollars = 5 }) => ({
+                createdAt,
                 sponsorEntity: { login },
+                tier: { monthlyPriceInDollars: amountInDollars },
               })),
               pageInfo: { hasNextPage, endCursor },
             },
@@ -40,61 +42,88 @@ beforeEach(() => {
 });
 
 describe("checkSponsorship", () => {
-  it("후원 중인 경우 true를 반환한다", async () => {
+  it("후원 이력이 없으면 sponsored: false를 반환한다", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(makeSponsorshipResponse(["octocat"])),
+      vi.fn().mockResolvedValue(makeSponsorshipResponse([{ login: "someone-else" }])),
     );
 
     const result = await checkSponsorship("octocat", "DaleStudy", "test-token");
-    expect(result).toBe(true);
+    expect(result).toEqual({ sponsored: false, lastSponsoredAt: null, amountInDollars: null });
   });
 
-  it("대소문자 구분 없이 true를 반환한다", async () => {
+  it("후원 중인 경우 sponsored: true와 날짜/금액을 반환한다", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(makeSponsorshipResponse(["OctoCAT"])),
+      vi.fn().mockResolvedValue(
+        makeSponsorshipResponse([{ login: "octocat", createdAt: "2024-06-01T00:00:00Z", amountInDollars: 10 }]),
+      ),
     );
 
     const result = await checkSponsorship("octocat", "DaleStudy", "test-token");
-    expect(result).toBe(true);
+    expect(result).toEqual({
+      sponsored: true,
+      lastSponsoredAt: "2024-06-01T00:00:00Z",
+      amountInDollars: 10,
+    });
   });
 
-  it("후원하지 않는 경우 false를 반환한다", async () => {
+  it("대소문자 구분 없이 일치하면 sponsored: true를 반환한다", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(makeSponsorshipResponse(["someone-else"])),
+      vi.fn().mockResolvedValue(makeSponsorshipResponse([{ login: "OctoCAT" }])),
     );
 
     const result = await checkSponsorship("octocat", "DaleStudy", "test-token");
-    expect(result).toBe(false);
+    expect(result.sponsored).toBe(true);
   });
 
-  it("페이지네이션으로 다음 페이지에서 찾으면 true를 반환한다", async () => {
+  it("여러 후원 이력 중 가장 최근 날짜를 반환한다", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce(
+          makeSponsorshipResponse([
+            { login: "octocat", createdAt: "2024-01-01T00:00:00Z", amountInDollars: 5 },
+          ], true, "cursor1"),
+        )
+        .mockResolvedValueOnce(
+          makeSponsorshipResponse([
+            { login: "octocat", createdAt: "2024-09-01T00:00:00Z", amountInDollars: 10 },
+          ]),
+        ),
+    );
+
+    const result = await checkSponsorship("octocat", "DaleStudy", "test-token");
+    expect(result.lastSponsoredAt).toBe("2024-09-01T00:00:00Z");
+    expect(result.amountInDollars).toBe(10);
+  });
+
+  it("페이지네이션으로 다음 페이지에서 찾으면 sponsored: true를 반환한다", async () => {
     const mockFetch = vi
       .fn()
       .mockResolvedValueOnce(
-        makeSponsorshipResponse(["alice", "bob"], true, "cursor1"),
+        makeSponsorshipResponse([{ login: "alice" }, { login: "bob" }], true, "cursor1"),
       )
-      .mockResolvedValueOnce(makeSponsorshipResponse(["octocat"]));
+      .mockResolvedValueOnce(makeSponsorshipResponse([{ login: "octocat" }]));
     vi.stubGlobal("fetch", mockFetch);
 
     const result = await checkSponsorship("octocat", "DaleStudy", "test-token");
-    expect(result).toBe(true);
+    expect(result.sponsored).toBe(true);
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
-  it("모든 페이지 순회 후 없으면 false를 반환한다", async () => {
+  it("모든 페이지 순회 후 없으면 sponsored: false를 반환한다", async () => {
     const mockFetch = vi
       .fn()
       .mockResolvedValueOnce(
-        makeSponsorshipResponse(["alice"], true, "cursor1"),
+        makeSponsorshipResponse([{ login: "alice" }], true, "cursor1"),
       )
-      .mockResolvedValueOnce(makeSponsorshipResponse(["bob"]));
+      .mockResolvedValueOnce(makeSponsorshipResponse([{ login: "bob" }]));
     vi.stubGlobal("fetch", mockFetch);
 
     const result = await checkSponsorship("octocat", "DaleStudy", "test-token");
-    expect(result).toBe(false);
+    expect(result.sponsored).toBe(false);
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
@@ -117,7 +146,7 @@ describe("checkSponsorship", () => {
   it("올바른 GraphQL 엔드포인트와 헤더로 요청한다", async () => {
     const mockFetch = vi
       .fn()
-      .mockResolvedValue(makeSponsorshipResponse(["octocat"]));
+      .mockResolvedValue(makeSponsorshipResponse([{ login: "octocat" }]));
     vi.stubGlobal("fetch", mockFetch);
 
     await checkSponsorship("octocat", "DaleStudy", "my-token");
@@ -125,6 +154,33 @@ describe("checkSponsorship", () => {
     const [url, options] = mockFetch.mock.calls[0];
     expect(url).toBe("https://api.github.com/graphql");
     expect(options.headers["Authorization"]).toBe("Bearer my-token");
+  });
+});
+
+describe("getTeamCreatedAt", () => {
+  it("팀 생성일을 반환한다", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ created_at: "2024-03-01T00:00:00Z" }),
+      }),
+    );
+
+    const result = await getTeamCreatedAt("DaleStudy", "members", "test-token");
+    expect(result).toBe("2024-03-01T00:00:00Z");
+  });
+
+  it("팀 조회 실패 시 예외를 던진다", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ message: "Not Found" }),
+      }),
+    );
+
+    await expect(
+      getTeamCreatedAt("DaleStudy", "nonexistent", "test-token"),
+    ).rejects.toThrow("Failed to get team info");
   });
 });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -143,6 +143,36 @@ export async function getTeamCreatedAt(
 }
 
 /**
+ * GitHub 팀 멤버 추가 또는 초대
+ */
+export async function inviteToTeam(
+  org: string,
+  teamSlug: string,
+  username: string,
+  token: string,
+): Promise<"active" | "pending"> {
+  const response = await fetch(
+    `https://api.github.com/orgs/${org}/teams/${teamSlug}/memberships/${username}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "DaleStudy-Community-Manager",
+      },
+    },
+  );
+
+  const data = (await response.json()) as any;
+
+  if (!response.ok) {
+    throw new Error(`Failed to invite to team: ${JSON.stringify(data)}`);
+  }
+
+  return data.state;
+}
+
+/**
  * JWT 생성 (RS256)
  */
 async function createJWT(

--- a/src/github.ts
+++ b/src/github.ts
@@ -29,21 +29,31 @@ export async function getInstallationToken(env: Env): Promise<string> {
   return tokenData.token;
 }
 
+export interface SponsorshipInfo {
+  sponsored: boolean;
+  lastSponsoredAt: string | null;
+  amountInDollars: number | null;
+}
+
 /**
- * GitHub 후원 여부 확인 (과거 후원 포함, GraphQL 페이지네이션)
+ * GitHub 후원 상세 정보 확인 (과거 후원 포함, GraphQL 페이지네이션)
  */
 export async function checkSponsorship(
   githubUsername: string,
   org: string,
   token: string,
-): Promise<boolean> {
+): Promise<SponsorshipInfo> {
   const query = `
     query($org: String!, $cursor: String) {
       organization(login: $org) {
         sponsorshipsAsMaintainer(first: 100, after: $cursor, activeOnly: false) {
           nodes {
+            createdAt
             sponsorEntity {
               ... on User { login }
+            }
+            tier {
+              monthlyPriceInDollars
             }
           }
           pageInfo {
@@ -56,6 +66,7 @@ export async function checkSponsorship(
   `;
 
   let cursor: string | null = null;
+  let latest: { createdAt: string; amountInDollars: number } | null = null;
 
   while (true) {
     const response = await fetch("https://api.github.com/graphql", {
@@ -78,19 +89,57 @@ export async function checkSponsorship(
     const sponsorships = result.data?.organization?.sponsorshipsAsMaintainer;
     const nodes = sponsorships?.nodes ?? [];
 
-    const found = nodes.some(
-      (n: any) =>
-        n.sponsorEntity?.login?.toLowerCase() === githubUsername.toLowerCase(),
-    );
-
-    if (found) return true;
+    for (const node of nodes) {
+      if (node.sponsorEntity?.login?.toLowerCase() !== githubUsername.toLowerCase()) continue;
+      if (!latest || node.createdAt > latest.createdAt) {
+        latest = {
+          createdAt: node.createdAt,
+          amountInDollars: node.tier?.monthlyPriceInDollars ?? 0,
+        };
+      }
+    }
 
     if (!sponsorships?.pageInfo?.hasNextPage) break;
-
     cursor = sponsorships.pageInfo.endCursor;
   }
 
-  return false;
+  if (!latest) {
+    return { sponsored: false, lastSponsoredAt: null, amountInDollars: null };
+  }
+
+  return {
+    sponsored: true,
+    lastSponsoredAt: latest.createdAt,
+    amountInDollars: latest.amountInDollars,
+  };
+}
+
+/**
+ * GitHub 팀 생성일 조회
+ */
+export async function getTeamCreatedAt(
+  org: string,
+  teamSlug: string,
+  token: string,
+): Promise<string> {
+  const response = await fetch(
+    `https://api.github.com/orgs/${org}/teams/${teamSlug}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "DaleStudy-Community-Manager",
+      },
+    },
+  );
+
+  const data = (await response.json()) as any;
+
+  if (!data.created_at) {
+    throw new Error(`Failed to get team info: ${JSON.stringify(data)}`);
+  }
+
+  return data.created_at;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { Env, RoleTeamConfig } from "./types.js";
-import { getInstallationToken, checkSponsorship, getTeamCreatedAt } from "./github.js";
+import { getInstallationToken, checkSponsorship, getTeamCreatedAt, inviteToTeam } from "./github.js";
 
 export default {
   async fetch(
@@ -62,6 +62,11 @@ async function handleVerify(interaction: any, env: Env): Promise<string> {
     return `❌ 가장 최근 후원일(${sponsorship.lastSponsoredAt!.slice(0, 10)})이 팀 생성일(${teamCreatedAt.slice(0, 10)}) 이전입니다.`;
   }
 
-  // TODO: 팀 초대 → 역할 부여
-  return "🔧 후원 확인됨. 팀 초대/역할 부여 구현 예정입니다.";
+  const state = await inviteToTeam(env.GITHUB_ORG, teamConfig.teamSlug, githubUsername, token);
+
+  if (state === "active") {
+    return "✅ 팀에 바로 추가되었습니다.";
+  }
+
+  return "✅ 초대 메일을 발송했습니다. 수락 후 팀에 합류됩니다.";
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { Env, RoleTeamConfig } from "./types.js";
 import { getInstallationToken, checkSponsorship, getTeamCreatedAt, inviteToTeam } from "./github.js";
+import { verifySignature } from "./discord.js";
 
 export default {
   async fetch(
@@ -10,7 +11,15 @@ export default {
       return new Response("Method Not Allowed", { status: 405 });
     }
 
+    const signature = request.headers.get("X-Signature-Ed25519") ?? "";
+    const timestamp = request.headers.get("X-Signature-Timestamp") ?? "";
     const body = await request.text();
+
+    const isValid = await verifySignature(env.DISCORD_PUBLIC_KEY, signature, timestamp, body);
+    if (!isValid) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
     const interaction = JSON.parse(body);
 
     // PING

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { Env, RoleTeamConfig } from "./types.js";
-import { getInstallationToken, checkSponsorship } from "./github.js";
+import { getInstallationToken, checkSponsorship, getTeamCreatedAt } from "./github.js";
 
 export default {
   async fetch(
@@ -37,19 +37,29 @@ async function handleVerify(interaction: any, env: Env): Promise<string> {
   const teamValue = options.find((o: any) => o.name === "team")
     ?.value as string;
 
-  // const config: RoleTeamConfig[] = JSON.parse(env.ROLE_TEAM_CONFIG);
-  // const roleConfig = config.find((c) => c.value === roleValue);
-  // const teamConfig = config.find((c) => c.value === teamValue);
+  const config: RoleTeamConfig[] = JSON.parse(env.ROLE_TEAM_CONFIG);
+  const roleConfig = config.find((c) => c.value === roleValue);
+  const teamConfig = config.find((c) => c.value === teamValue);
 
-  // if (!roleConfig || !teamConfig) {
-  //   return "⚠️ 잘못된 role 또는 team 값입니다.";
-  // }
+  if (!roleConfig || !teamConfig) {
+    return "⚠️ 잘못된 role 또는 team 값입니다.";
+  }
 
   const token = await getInstallationToken(env);
-  const isSponsored = await checkSponsorship(githubUsername, env.GITHUB_ORG, token);
+  const sponsorship = await checkSponsorship(githubUsername, env.GITHUB_ORG, token);
 
-  if (!isSponsored) {
+  if (!sponsorship.sponsored) {
     return "❌ 해당 GitHub 계정의 후원 내역을 찾을 수 없습니다.";
+  }
+
+  if ((sponsorship.amountInDollars ?? 0) < 5) {
+    return `❌ 후원 금액이 $5 미만입니다. (현재: $${sponsorship.amountInDollars})`;
+  }
+
+  const teamCreatedAt = await getTeamCreatedAt(env.GITHUB_ORG, teamConfig.teamSlug, token);
+
+  if (sponsorship.lastSponsoredAt! < teamCreatedAt) {
+    return `❌ 가장 최근 후원일(${sponsorship.lastSponsoredAt!.slice(0, 10)})이 팀 생성일(${teamCreatedAt.slice(0, 10)}) 이전입니다.`;
   }
 
   // TODO: 팀 초대 → 역할 부여


### PR DESCRIPTION
## Summary
후원 검증 로직 전면 재작성 및 Discord Ed25519 서명 검증 추가.

- `discord.ts` 추가: Discord 요청의 Ed25519 서명 검증 (`verifySignature`)
- 후원 확인을 GitHub App token 대신 PAT(`GH_PAT`)으로 전환
  - GraphQL API로 후원 이력 전체 조회 (금액 포함)
- GitHub 팀 초대(`inviteToTeam`), 팀 생성일 조회(`getTeamCreatedAt`) 함수 추가
- 팀 생성일 이후 후원 합계 $5 이상 조건 검증 로직 구현
- `@types/node` 추가 및 `package.json`에 `"type": "module"` 설정
- 단위 테스트 보강

## 관련 이슈
closes #27