### PR TITLE
add roleteamconfig

### DIFF
--- a/scripts/register.ts
+++ b/scripts/register.ts
@@ -7,7 +7,9 @@ const ROLE_TEAM_CONFIG = process.env.ROLE_TEAM_CONFIG;
 
 if (!BOT_TOKEN || !APPLICATION_ID || !GUILD_ID || !ROLE_TEAM_CONFIG) {
   console.error("필요한 환경 변수가 설정되지 않았습니다.");
-  console.error("필요: DISCORD_BOT_TOKEN, DISCORD_APPLICATION_ID, DISCORD_GUILD_ID, ROLE_TEAM_CONFIG");
+  console.error(
+    "필요: DISCORD_BOT_TOKEN, DISCORD_APPLICATION_ID, DISCORD_GUILD_ID, ROLE_TEAM_CONFIG",
+  );
   process.exit(1);
 }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,7 +6,7 @@
   "compatibility_flags": ["nodejs_compat"],
   "vars": {
     "GITHUB_ORG": "DaleStudy",
-    "ROLE_TEAM_CONFIG": "[{\"value\":\"placeholder\",\"label\":\"Placeholder\",\"discordRoleId\":\"REPLACE_ME\",\"teamSlug\":\"REPLACE_ME\"}]",
+    "ROLE_TEAM_CONFIG": "[{\"value\":\"test\",\"label\":\"test\",\"discordRoleId\":\"1233209102495383572\",\"teamSlug\":\"test\"}]",
   },
   "kv_namespaces": [],
   "durable_objects": {


### PR DESCRIPTION
## Summary
`ROLE_TEAM_CONFIG` 환경변수를 `wrangler.jsonc`에 추가.

- team/role 값을 Discord roleId, GitHub teamSlug에 매핑하는 JSON 설정 추가
- 형식: `[{"value":"...","label":"...","discordRoleId":"...","teamSlug":"..."}]`

## 관련 이슈
closes #28