### PR TITLE
Update secrets naming and sponsorship tier validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,14 +44,18 @@ jobs:
             DISCORD_BOT_TOKEN
             DISCORD_GUILD_ID
             DISCORD_ROLE_ID
+            DISCORD_APPLICATION_ID
             APP_ID
             APP_INSTALLATION_ID
             APP_PRIVATE_KEY
+            GH_PAT
         env:
           DISCORD_PUBLIC_KEY: ${{ secrets.DISCORD_PUBLIC_KEY }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
           DISCORD_ROLE_ID: ${{ secrets.DISCORD_ROLE_ID }}
+          DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_APPLICATION_ID }}
           APP_ID: ${{ secrets.APP_ID }}
           APP_INSTALLATION_ID: ${{ secrets.APP_INSTALLATION_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GH_PAT: ${{ secrets.GH_PAT }}

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -6,15 +6,17 @@ const mockEnv: Env = {
   DISCORD_PUBLIC_KEY: "test-public-key",
   DISCORD_BOT_TOKEN: "test-bot-token",
   DISCORD_GUILD_ID: "test-guild-id",
+  DISCORD_APPLICATION_ID: "test-app-id",
   GITHUB_ORG: "DaleStudy",
   APP_ID: "123456",
   APP_INSTALLATION_ID: "789",
   APP_PRIVATE_KEY: "",
   ROLE_TEAM_CONFIG: "[]",
+  GH_PAT: "test-pat",
 };
 
 function makeSponsorshipResponse(
-  sponsors: { login: string; createdAt?: string; amountInDollars?: number }[],
+  sponsors: { login: string; createdAt?: string; isOneTimePayment?: boolean; amount?: number }[],
   hasNextPage = false,
   endCursor: string | null = null,
 ) {
@@ -24,10 +26,11 @@ function makeSponsorshipResponse(
         data: {
           organization: {
             sponsorshipsAsMaintainer: {
-              nodes: sponsors.map(({ login, createdAt = "2024-01-01T00:00:00Z", amountInDollars = 5 }) => ({
+              nodes: sponsors.map(({ login, createdAt = "2024-01-01T00:00:00Z", isOneTimePayment = true, amount = 5 }) => ({
                 createdAt,
+                isOneTimePayment,
+                tier: { monthlyPriceInDollars: amount },
                 sponsorEntity: { login },
-                tier: { monthlyPriceInDollars: amountInDollars },
               })),
               pageInfo: { hasNextPage, endCursor },
             },
@@ -49,14 +52,14 @@ describe("checkSponsorship", () => {
     );
 
     const result = await checkSponsorship("octocat", "DaleStudy", "test-token");
-    expect(result).toEqual({ sponsored: false, lastSponsoredAt: null, amountInDollars: null });
+    expect(result).toEqual({ sponsored: false, lastSponsoredAt: null, isOneTimePayment: null, amount: null });
   });
 
-  it("후원 중인 경우 sponsored: true와 날짜/금액을 반환한다", async () => {
+  it("후원 중인 경우 sponsored: true와 날짜를 반환한다", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
-        makeSponsorshipResponse([{ login: "octocat", createdAt: "2024-06-01T00:00:00Z", amountInDollars: 10 }]),
+        makeSponsorshipResponse([{ login: "octocat", createdAt: "2024-06-01T00:00:00Z" }]),
       ),
     );
 
@@ -64,7 +67,8 @@ describe("checkSponsorship", () => {
     expect(result).toEqual({
       sponsored: true,
       lastSponsoredAt: "2024-06-01T00:00:00Z",
-      amountInDollars: 10,
+      isOneTimePayment: true,
+      amount: 5,
     });
   });
 
@@ -84,19 +88,18 @@ describe("checkSponsorship", () => {
       vi.fn()
         .mockResolvedValueOnce(
           makeSponsorshipResponse([
-            { login: "octocat", createdAt: "2024-01-01T00:00:00Z", amountInDollars: 5 },
+            { login: "octocat", createdAt: "2024-01-01T00:00:00Z" },
           ], true, "cursor1"),
         )
         .mockResolvedValueOnce(
           makeSponsorshipResponse([
-            { login: "octocat", createdAt: "2024-09-01T00:00:00Z", amountInDollars: 10 },
+            { login: "octocat", createdAt: "2024-09-01T00:00:00Z" },
           ]),
         ),
     );
 
     const result = await checkSponsorship("octocat", "DaleStudy", "test-token");
     expect(result.lastSponsoredAt).toBe("2024-09-01T00:00:00Z");
-    expect(result.amountInDollars).toBe(10);
   });
 
   it("페이지네이션으로 다음 페이지에서 찾으면 sponsored: true를 반환한다", async () => {

--- a/src/github.ts
+++ b/src/github.ts
@@ -32,6 +32,8 @@ export async function getInstallationToken(env: Env): Promise<string> {
 export interface SponsorshipInfo {
   sponsored: boolean;
   lastSponsoredAt: string | null;
+  isOneTimePayment: boolean | null;
+  amount: number | null;
 }
 
 /**
@@ -48,6 +50,8 @@ export async function checkSponsorship(
         sponsorshipsAsMaintainer(first: 100, after: $cursor, activeOnly: false) {
           nodes {
             createdAt
+            isOneTimePayment
+            tier { monthlyPriceInDollars }
             sponsorEntity {
               ... on User { login }
             }
@@ -63,6 +67,8 @@ export async function checkSponsorship(
 
   let cursor: string | null = null;
   let lastSponsoredAt: string | null = null;
+  let isOneTimePayment: boolean | null = null;
+  let amount: number | null = null;
 
   while (true) {
     const response = await fetch("https://api.github.com/graphql", {
@@ -87,8 +93,10 @@ export async function checkSponsorship(
 
     for (const node of nodes) {
       if (node.sponsorEntity?.login?.toLowerCase() !== githubUsername.toLowerCase()) continue;
-if (!lastSponsoredAt || node.createdAt > lastSponsoredAt) {
+      if (!lastSponsoredAt || node.createdAt > lastSponsoredAt) {
         lastSponsoredAt = node.createdAt;
+        isOneTimePayment = node.isOneTimePayment ?? null;
+        amount = node.tier?.monthlyPriceInDollars ?? null;
       }
     }
 
@@ -97,10 +105,10 @@ if (!lastSponsoredAt || node.createdAt > lastSponsoredAt) {
   }
 
   if (!lastSponsoredAt) {
-    return { sponsored: false, lastSponsoredAt: null };
+    return { sponsored: false, lastSponsoredAt: null, isOneTimePayment: null, amount: null };
   }
 
-  return { sponsored: true, lastSponsoredAt };
+  return { sponsored: true, lastSponsoredAt, isOneTimePayment, amount };
 }
 
 /**

--- a/src/github.ts
+++ b/src/github.ts
@@ -32,11 +32,10 @@ export async function getInstallationToken(env: Env): Promise<string> {
 export interface SponsorshipInfo {
   sponsored: boolean;
   lastSponsoredAt: string | null;
-  amountInDollars: number | null;
 }
 
 /**
- * GitHub 후원 상세 정보 확인 (과거 후원 포함, GraphQL 페이지네이션)
+ * GitHub 후원 여부 확인 (과거 후원 포함, GraphQL 페이지네이션)
  */
 export async function checkSponsorship(
   githubUsername: string,
@@ -52,9 +51,6 @@ export async function checkSponsorship(
             sponsorEntity {
               ... on User { login }
             }
-            tier {
-              monthlyPriceInDollars
-            }
           }
           pageInfo {
             hasNextPage
@@ -66,7 +62,7 @@ export async function checkSponsorship(
   `;
 
   let cursor: string | null = null;
-  let latest: { createdAt: string; amountInDollars: number } | null = null;
+  let lastSponsoredAt: string | null = null;
 
   while (true) {
     const response = await fetch("https://api.github.com/graphql", {
@@ -91,11 +87,8 @@ export async function checkSponsorship(
 
     for (const node of nodes) {
       if (node.sponsorEntity?.login?.toLowerCase() !== githubUsername.toLowerCase()) continue;
-      if (!latest || node.createdAt > latest.createdAt) {
-        latest = {
-          createdAt: node.createdAt,
-          amountInDollars: node.tier?.monthlyPriceInDollars ?? 0,
-        };
+if (!lastSponsoredAt || node.createdAt > lastSponsoredAt) {
+        lastSponsoredAt = node.createdAt;
       }
     }
 
@@ -103,15 +96,11 @@ export async function checkSponsorship(
     cursor = sponsorships.pageInfo.endCursor;
   }
 
-  if (!latest) {
-    return { sponsored: false, lastSponsoredAt: null, amountInDollars: null };
+  if (!lastSponsoredAt) {
+    return { sponsored: false, lastSponsoredAt: null };
   }
 
-  return {
-    sponsored: true,
-    lastSponsoredAt: latest.createdAt,
-    amountInDollars: latest.amountInDollars,
-  };
+  return { sponsored: true, lastSponsoredAt };
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export default {
   async fetch(
     request: Request,
     env: Env,
+    ctx: ExecutionContext,
   ): Promise<Response> {
     if (request.method !== "POST") {
       return new Response("Method Not Allowed", { status: 405 });
@@ -29,13 +30,28 @@ export default {
 
     // APPLICATION_COMMAND
     if (interaction.type === 2) {
-      const message = await handleVerify(interaction, env);
-      return Response.json({ type: 4, data: { content: message } });
+      ctx.waitUntil(
+        handleVerify(interaction, env).then((message) =>
+          editFollowup(env.DISCORD_APPLICATION_ID, interaction.token, message),
+        ),
+      );
+      return Response.json({ type: 5 });
     }
 
     return new Response("Unknown interaction type", { status: 400 });
   },
 };
+
+async function editFollowup(applicationId: string, token: string, content: string): Promise<void> {
+  await fetch(
+    `https://discord.com/api/v10/webhooks/${applicationId}/${token}/messages/@original`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    },
+  );
+}
 
 async function handleVerify(interaction: any, env: Env): Promise<string> {
   const options = interaction.data?.options ?? [];
@@ -55,14 +71,10 @@ async function handleVerify(interaction: any, env: Env): Promise<string> {
   }
 
   const token = await getInstallationToken(env);
-  const sponsorship = await checkSponsorship(githubUsername, env.GITHUB_ORG, token);
+  const sponsorship = await checkSponsorship(githubUsername, env.GITHUB_ORG, env.GH_PAT);
 
   if (!sponsorship.sponsored) {
     return "❌ 해당 GitHub 계정의 후원 내역을 찾을 수 없습니다.";
-  }
-
-  if ((sponsorship.amountInDollars ?? 0) < 5) {
-    return `❌ 후원 금액이 $5 미만입니다. (현재: $${sponsorship.amountInDollars})`;
   }
 
   const teamCreatedAt = await getTeamCreatedAt(env.GITHUB_ORG, teamConfig.teamSlug, token);

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,10 @@ async function handleVerify(interaction: any, env: Env): Promise<string> {
     return "❌ 해당 GitHub 계정의 후원 내역을 찾을 수 없습니다.";
   }
 
+  if (!sponsorship.isOneTimePayment || (sponsorship.amount ?? 0) < 5) {
+    return `❌ one-time $5 이상 후원자만 가입 가능합니다. (현재: ${sponsorship.isOneTimePayment ? `$${sponsorship.amount ?? 0} one-time` : "정기 후원"})`;
+  }
+
   const teamCreatedAt = await getTeamCreatedAt(env.GITHUB_ORG, teamConfig.teamSlug, token);
 
   if (sponsorship.lastSponsoredAt! < teamCreatedAt) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,4 +14,6 @@ export interface Env {
   APP_INSTALLATION_ID: string;
   APP_PRIVATE_KEY: string;
   ROLE_TEAM_CONFIG: string;
+  GH_PAT: string;
+  DISCORD_APPLICATION_ID: string;
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,7 +6,7 @@
   "compatibility_flags": ["nodejs_compat"],
   "vars": {
     "GITHUB_ORG": "DaleStudy",
-    "ROLE_TEAM_CONFIG": "[{\"value\":\"test\",\"label\":\"leetcode07\",\"discordRoleId\":\"1233209102495383572\",\"teamSlug\":\"leetcode07\"}]",
+    "ROLE_TEAM_CONFIG": "[{\"value\":\"leetcode07\",\"label\":\"leetcode07\",\"discordRoleId\":\"1233209102495383572\",\"teamSlug\":\"leetcode07\"}]",
   },
   "kv_namespaces": [],
   "durable_objects": {


### PR DESCRIPTION
## Summary
- `GITHUB_PAT` → `GH_PAT` 으로 rename (GitHub Actions 예약어 충돌 방지)
- CI deploy workflow에 `DISCORD_APPLICATION_ID`, `GH_PAT` 추가
- 후원 tier/금액 조회를 classic PAT(`GH_PAT`)으로 처리
- 후원 시작일과 팀 생성일 비교해서 유효성 검증

## Test plan
- [ ] GitHub Actions secrets에 `GH_PAT`, `DISCORD_APPLICATION_ID` 추가 확인
- [ ] CI 배포 정상 동작 확인
- [ ] `/verify` 커맨드로 후원 날짜 검증 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)