### PR TITLE
Add Discord role assignment after successful verification

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -22,6 +22,32 @@ export async function verifySignature(
   return crypto.subtle.verify("Ed25519", key, signatureBytes, message);
 }
 
+/**
+ * Discord 역할 부여
+ */
+export async function assignRole(
+  guildId: string,
+  userId: string,
+  roleId: string,
+  botToken: string,
+): Promise<void> {
+  const response = await fetch(
+    `https://discord.com/api/v10/guilds/${guildId}/members/${userId}/roles/${roleId}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bot ${botToken}`,
+        "Content-Type": "application/json",
+      },
+    },
+  );
+
+  if (!response.ok && response.status !== 204) {
+    const data = await response.json() as any;
+    throw new Error(`Failed to assign Discord role: ${JSON.stringify(data)}`);
+  }
+}
+
 function hexToBytes(hex: string): Uint8Array {
   const bytes = new Uint8Array(hex.length / 2);
   for (let i = 0; i < bytes.length; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { Env, RoleTeamConfig } from "./types.js";
 import { getInstallationToken, checkSponsorship, getTeamCreatedAt, inviteToTeam } from "./github.js";
-import { verifySignature } from "./discord.js";
+import { verifySignature, assignRole } from "./discord.js";
 
 export default {
   async fetch(
@@ -87,7 +87,11 @@ async function handleVerify(interaction: any, env: Env): Promise<string> {
     return `❌ 가장 최근 후원일(${sponsorship.lastSponsoredAt!.slice(0, 10)})이 팀 생성일(${teamCreatedAt.slice(0, 10)}) 이전입니다.`;
   }
 
-  const state = await inviteToTeam(env.GITHUB_ORG, teamConfig.teamSlug, githubUsername, token);
+  const discordUserId = interaction.member?.user?.id as string;
+  const [state] = await Promise.all([
+    inviteToTeam(env.GITHUB_ORG, teamConfig.teamSlug, githubUsername, token),
+    assignRole(env.DISCORD_GUILD_ID, discordUserId, roleConfig.discordRoleId, env.DISCORD_BOT_TOKEN),
+  ]);
 
   const amountLabel = `$${sponsorship.amount} one-time`;
 


### PR DESCRIPTION
## Summary
- 후원 검증 성공 시 Discord 역할을 자동으로 부여
- GitHub 팀 초대와 Discord 역할 부여를 병렬로 처리
- `discord.ts`에 `assignRole` 함수 추가

## Test plan
- [ ] `/verify` 커맨드 성공 시 Discord 역할이 자동으로 부여되는지 확인
- [ ] GitHub 팀 초대와 동시에 역할이 부여되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)