### PR TITLE
Send error feedback to Discord on failure instead of buffering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,9 @@ export default {
     // APPLICATION_COMMAND
     if (interaction.type === 2) {
       ctx.waitUntil(
-        handleVerify(interaction, env).then((message) =>
-          editFollowup(env.DISCORD_APPLICATION_ID, interaction.token, message),
-        ),
+        handleVerify(interaction, env)
+          .then((message) => editFollowup(env.DISCORD_APPLICATION_ID, interaction.token, message))
+          .catch((err) => editFollowup(env.DISCORD_APPLICATION_ID, interaction.token, `⚠️ 오류가 발생했습니다: ${err?.message ?? "알 수 없는 오류"}`)),
       );
       return Response.json({ type: 5 });
     }


### PR DESCRIPTION
## Summary
검증 실패 시 즉각 에러 피드백 전송으로 변경.

- 기존: 에러 발생 시 Discord에 아무 응답 없이 버퍼링됨
- 변경: `catch` 블록에서 `editFollowup`으로 에러 메시지 즉시 전송
- 사용자가 실패 원인을 Discord에서 바로 확인 가능

## 관련 이슈
closes #28