### PR TITLE
Accept discord_user_id as slash command option instead of interaction…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deploy": "wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest",
-    "register": "tsx scripts/register.ts"
+    "register": "tsx scripts/register-commands.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250407.0",

--- a/scripts/register-commands.ts
+++ b/scripts/register-commands.ts
@@ -1,0 +1,57 @@
+const APPLICATION_ID = process.env.DISCORD_APPLICATION_ID!;
+const BOT_TOKEN = process.env.DISCORD_BOT_TOKEN!;
+const GUILD_ID = process.env.DISCORD_GUILD_ID!;
+const ROLE_TEAM_CONFIG = JSON.parse(process.env.ROLE_TEAM_CONFIG!);
+
+const choices = ROLE_TEAM_CONFIG.map((c: { value: string; label: string }) => ({
+  name: c.label,
+  value: c.value,
+}));
+
+const command = {
+  name: "verify",
+  description: "후원 여부를 확인하고 팀에 초대합니다.",
+  options: [
+    {
+      name: "github_username",
+      description: "GitHub 사용자 이름",
+      type: 3, // STRING
+      required: true,
+    },
+    {
+      name: "discord_user_id",
+      description: "Discord 사용자 ID",
+      type: 3, // STRING
+      required: true,
+    },
+    {
+      name: "team",
+      description: "참여할 팀",
+      type: 3, // STRING
+      required: true,
+      choices,
+    },
+    {
+      name: "role",
+      description: "부여할 역할",
+      type: 3, // STRING
+      required: true,
+      choices,
+    },
+  ],
+};
+
+const response = await fetch(
+  `https://discord.com/api/v10/applications/${APPLICATION_ID}/guilds/${GUILD_ID}/commands`,
+  {
+    method: "PUT",
+    headers: {
+      Authorization: `Bot ${BOT_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify([command]),
+  },
+);
+
+const result = await response.json();
+console.log(JSON.stringify(result, null, 2));

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ async function handleVerify(interaction: any, env: Env): Promise<string> {
     return `❌ 가장 최근 후원일(${sponsorship.lastSponsoredAt!.slice(0, 10)})이 팀 생성일(${teamCreatedAt.slice(0, 10)}) 이전입니다.`;
   }
 
-  const discordUserId = interaction.member?.user?.id as string;
+  const discordUserId = options.find((o: any) => o.name === "discord_user_id")?.value as string;
   const [state] = await Promise.all([
     inviteToTeam(env.GITHUB_ORG, teamConfig.teamSlug, githubUsername, token),
     assignRole(env.DISCORD_GUILD_ID, discordUserId, roleConfig.discordRoleId, env.DISCORD_BOT_TOKEN),


### PR DESCRIPTION
… member

- Add discord_user_id option to /verify command
- Add register-commands.ts script for command registration