### PR TITLE
Change discord_user_id option type to USER

### DIFF
--- a/scripts/register-commands.ts
+++ b/scripts/register-commands.ts
@@ -20,8 +20,8 @@ const command = {
     },
     {
       name: "discord_user_id",
-      description: "Discord 사용자 ID",
-      type: 3, // STRING
+      description: "Discord 사용자",
+      type: 6, // USER
       required: true,
     },
     {


### PR DESCRIPTION
## Summary
- `/verify` 커맨드의 `discord_user_id` 옵션 타입을 `STRING` → `USER`로 변경
- Discord ID를 수동으로 복사할 필요 없이 @멘션으로 유저 선택 가능

## Test plan
- [ ] `/verify` 실행 시 `discord_user_id` 옵션에서 유저를 @멘션으로 선택 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)