### PR TITLE
fix : message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 .dev.vars
 *.pem
+.http

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ async function handleVerify(interaction: any, env: Env): Promise<string> {
   console.log(`[verify] teamCreatedAt=${teamCreatedAt} eligibleRecords=${eligibleRecords.length} totalAmount=${totalAmount}`);
 
   if (totalAmount < 5) {
-    return `❌ 팀 생성일(${teamCreatedAt.slice(0, 10)}) 이후 후원 합계가 $5 미만입니다. (현재: $${totalAmount})`;
+    return `❌ 가장 최근 후원 금액($${totalAmount})이 $5 미만입니다. 여러 번 후원하셨다면 API 한계로 최근 1건만 확인됩니다. 운영자에게 문의해주세요.`;
   }
 
   const existingMembership = await getTeamMembership(env.GITHUB_ORG, teamConfig.teamSlug, githubUsername, token);


### PR DESCRIPTION
## Summary
후원 금액 부족 에러 메시지 개선 및 `.http` 파일 gitignore 추가.

- 에러 메시지 변경: `팀 생성일 이후 후원 합계 $5 미만` → 더 친절한 안내 메시지로 교체
  - API 한계(최근 1건만 확인)를 사용자에게 명시
  - 여러 번 후원한 경우 운영자 문의 유도
- `.gitignore`에 `.http` 추가 (REST Client 테스트 파일 추적 제외)

## 관련 이슈
ref #29