### PR TITLE
fix discord format check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,9 @@ async function handleChannelJoin(env: Env): Promise<void> {
 
   for (const msg of unprocessed) {
     const threadId = msg.threadId as string;
-    const parsed = parseJoinMessage(msg.content ?? "");
+    const content = msg.content ?? "";
+    console.log(`[cron] threadId=${threadId} content=${JSON.stringify(content)}`);
+    const parsed = parseJoinMessage(content);
 
     if (!parsed) {
       console.log(`[cron] parse failed threadId=${threadId}`);


### PR DESCRIPTION
## Summary
포럼 자동화 파싱 디버깅을 위한 content 로깅 추가.

- 처리 전 `msg.content` 값을 `JSON.stringify`로 로그 출력
- 파싱 실패 원인 추적을 위한 첫 번째 디버깅 단계
  - 이 로그를 통해 `content`가 항상 `""`임을 발견 → 이후 threadName fallback 도입으로 이어짐

## 관련 이슈
ref #29