### PR TITLE
Fix Discord forum post parsing

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -71,12 +71,19 @@ export async function getForumPosts(
   const posts = await Promise.all(
     allThreads.map(async (thread: any) => {
       const msgRes = await fetch(
-        `https://discord.com/api/v10/channels/${thread.id}/messages/${thread.id}`,
+        `https://discord.com/api/v10/channels/${thread.id}/messages?limit=10`,
         { headers },
       );
-      if (!msgRes.ok) return null;
-      const msg = await msgRes.json() as any;
-      return { ...msg, threadId: thread.id };
+      if (!msgRes.ok) {
+        const err = await msgRes.json();
+        console.log(`[discord] failed to fetch messages threadId=${thread.id} status=${msgRes.status} err=${JSON.stringify(err)}`);
+        return null;
+      }
+      const messages = await msgRes.json() as any[];
+      console.log(`[discord] threadId=${thread.id} messageCount=${messages.length} contents=${JSON.stringify(messages.map((m: any) => ({ id: m.id, bot: m.author?.bot, content: m.content })))}`);
+      const msg = messages.reverse().find((m: any) => !m.author?.bot);
+      if (!msg) return null;
+      return { ...msg, threadId: thread.id, threadName: thread.name };
     }),
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,23 +137,19 @@ interface ParsedJoinMessage {
 }
 
 function parseJoinMessage(content: string): ParsedJoinMessage | null {
-  const fields: Record<string, string> = {};
+  const normalized = content.replace(/：/g, ":");
 
-  for (const line of content.split("\n")) {
-    const colonIndex = line.indexOf(":");
-    if (colonIndex === -1) continue;
-    const key = line.slice(0, colonIndex).trim().toLowerCase();
-    const value = line.slice(colonIndex + 1).trim();
-    if (key && value) fields[key] = value;
-  }
+  const githubMatch = normalized.match(/\bgithub\s*:\s*([^\s:]+)/i);
+  const teamMatch = normalized.match(/\bteam\s*:\s*([^\s:]+)/i);
+  const roleMatch = normalized.match(/\brole\s*:\s*([^\s:]+)/i);
 
-  const githubUsername = fields["github"];
-  const team = fields["team"];
-  const role = fields["role"];
+  if (!githubMatch || !teamMatch || !roleMatch) return null;
 
-  if (!githubUsername || !team || !role) return null;
-
-  return { githubUsername, team, role };
+  return {
+    githubUsername: githubMatch[1],
+    team: teamMatch[1],
+    role: roleMatch[1],
+  };
 }
 
 async function handleChannelJoin(env: Env): Promise<void> {
@@ -169,15 +165,16 @@ async function handleChannelJoin(env: Env): Promise<void> {
   for (const msg of unprocessed) {
     const threadId = msg.threadId as string;
     const content = msg.content ?? "";
-    console.log(`[cron] threadId=${threadId} content=${JSON.stringify(content)}`);
-    const parsed = parseJoinMessage(content);
+    const threadName = msg.threadName ?? "";
+    console.log(`[cron] threadId=${threadId} content=${JSON.stringify(content)} threadName=${JSON.stringify(threadName)}`);
+    const parsed = parseJoinMessage(content) ?? parseJoinMessage(threadName);
 
     if (!parsed) {
       console.log(`[cron] parse failed threadId=${threadId}`);
       await replyToMessage(
         threadId,
         msg.id,
-        "⚠️ 메시지 형식이 올바르지 않습니다. 아래 형식으로 다시 작성해주세요.\n```\ngithub: your_github_username\nteam: team_name\nrole: role_name\n```",
+        "⚠️ 메시지 형식이 올바르지 않습니다. 포스트 **제목(title)** 에 아래 형식으로 한 줄로 작성해주세요.\n```\ngithub: username team: teamname role: rolename\n```",
         env.DISCORD_BOT_TOKEN,
       );
       await addReaction(threadId, msg.id, "❌", env.DISCORD_BOT_TOKEN);


### PR DESCRIPTION
## Summary
Discord 포럼 자동화의 메시지 파싱 실패 문제 수정. 트러블슈팅 과정에서 발견된 3가지 근본 원인을 모두 해결.

## 문제 및 원인

### 1. `content`가 항상 빈 값
- **원인**: `messages/{thread.id}` API가 starter message의 content를 빈 문자열로 반환
- **실제 원인**: 사용자가 포스트 본문(body)이 아닌 **제목(title)** 에 내용을 입력하고 있었음
- **해결**: `messages?limit=10`으로 변경하여 스레드 내 메시지 목록 조회, `thread.name`(제목)을 fallback으로 추가

### 2. 제목 필드의 줄바꿈 제거로 파싱 불가
- **원인**: Discord 포럼 제목은 단일 라인 — 줄바꿈 입력 시 제거되어 `"github: usernameteam: teamrole: role"` 형태로 연결됨
- **기존 파서**: `\n`으로 split → 한 줄로 합쳐지면 파싱 불가
- **해결**: 정규식 기반 파서로 교체 (`\bgithub\s*:\s*([^\s:]+)` 패턴)
  - 단일 라인 포맷 지원: `github: username team: teamname role: rolename`
  - 멀티라인 본문도 동일하게 처리
  - 전각 콜론(：) 정규화 추가 (한국어 입력기 대응)

### 3. `&& m.content` 조건으로 전체 스레드 필터링됨
- **원인**: 모든 메시지의 `content`가 빈 값이어서 `find((m) => !m.author?.bot && m.content)` 조건이 아무것도 찾지 못함 → `total=0`
- **해결**: `m.content` 조건 제거, threadName fallback에서 처리

## 변경 사항

**`src/discord.ts`**
- `messages/{thread.id}` → `messages?limit=10` 으로 변경
- 최신 10개 메시지 중 oldest non-bot 메시지 선택
- `threadName: thread.name` 반환값에 추가
- 에러/메시지 디버깅 로그 추가

**`src/index.ts`**
- `parseJoinMessage` 정규식 기반으로 재작성
- 전각 콜론(：) 정규화
- `parseJoinMessage(content) ?? parseJoinMessage(threadName)` fallback 추가
- 에러 메시지를 단일 라인 포맷 안내로 업데이트

## 최종 사용 포맷
포스트 **제목(title)** 에 한 줄로 입력:
```
github: username team: teamname role: rolename
```

## 관련 이슈
closes #29