### PR TITLE
Fix: 검증 실패 시 ✅ 대신 ❌ reaction 추가

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,8 @@ async function handleChannelJoin(env: Env): Promise<void> {
         env,
       );
       await replyToMessage(threadId, msg.id, result, env.DISCORD_BOT_TOKEN);
-      await addReaction(threadId, msg.id, "✅", env.DISCORD_BOT_TOKEN);
+      const reaction = result.startsWith("❌") || result.startsWith("⚠️") ? "❌" : "✅";
+      await addReaction(threadId, msg.id, reaction, env.DISCORD_BOT_TOKEN);
     } catch (err: any) {
       console.error(`[cron] error threadId=${threadId}`, err);
       await replyToMessage(


### PR DESCRIPTION
## 문제

후원 금액 부족 등 검증 실패 케이스에서 ✅ reaction이 달리는 버그.

```
❌ 가장 최근 후원 금액($1)이 $5 미만입니다. → ✅ reaction
```

## 원인

`processVerify`는 실패 케이스에서 예외를 던지지 않고 `❌`/`⚠️`로 시작하는 문자열을 반환함. `try` 블록이 정상 완료로 처리되어 항상 ✅ reaction이 추가됐음.

## 수정

응답 메시지의 첫 글자로 reaction 결정:

```typescript
const reaction = result.startsWith("❌") || result.startsWith("⚠️") ? "❌" : "✅";
```

| 응답 시작 | reaction |
|----------|---------|
| `✅` `ℹ️` | ✅ |
| `❌` `⚠️` | ❌ |
| 예외 발생 | ❌ |

## 관련 이슈
ref #29